### PR TITLE
Updated findAllWhere(). Params sent was misused.

### DIFF
--- a/src/Database/ActiveRecordModel.php
+++ b/src/Database/ActiveRecordModel.php
@@ -125,7 +125,7 @@ class ActiveRecordModel
         return $this->db->connect()
                         ->select()
                         ->from($this->tableName)
-                        ->where($where)
+                        ->where("$where = ?")
                         ->execute($params)
                         ->fetchAllClass(get_class($this));
     }


### PR DESCRIPTION
findAllWhere($where, $value) uses where($where) which does not work cause it expects it to be where("$where = ?")