### PR TITLE
Swap parameters to implode

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -357,7 +357,7 @@ class Database
             . " params):<br><pre>$query</pre><br>PARAMS ("
             . count($params)
             . "):<br><pre>"
-            . implode($params, "\n")
+            . implode("\n", $params)
             . "</pre>"
         );
     }


### PR DESCRIPTION
Shouldn't the parameters to implode be swapped?